### PR TITLE
add optional default argument to presence

### DIFF
--- a/lib/presence.ex
+++ b/lib/presence.ex
@@ -177,7 +177,7 @@ end
 
 defimpl Presence, for: BitString do
   def is_blank(string) do
-    String.strip(string) == ""
+    String.trim(string) == ""
   end
 
   def is_present(string), do: !is_blank(string)

--- a/lib/presence.ex
+++ b/lib/presence.ex
@@ -32,6 +32,8 @@ defprotocol Presence do
     | map
     | tuple
 
+  @type default :: any
+
   @doc ~S"""
   A value is blank if it's nil, false, empty, or a whitespace string.
 
@@ -157,6 +159,27 @@ defprotocol Presence do
   """
   @spec presence(t) :: t | nil
   def presence(value)
+
+  @doc ~S"""
+  Returns the `value` if it's present otherwise returns the `default`.
+
+      presence(value, default)
+
+  is equivalent to
+
+      is_present(value) ? value : default
+
+  For example, something like
+
+      format = (maybe_format |> presence()) || "csv"
+
+  becomes
+
+      format = maybe_format |> presence("csv")
+
+  """
+  @spec presence(t, default) :: t | default | nil
+  def presence(value, default)
 end
 
 defimpl Presence, for: Atom do
@@ -170,8 +193,8 @@ defimpl Presence, for: Atom do
 
   def is_present(atom), do: !is_blank(atom)
 
-  def presence(atom) do
-    if is_present(atom), do: atom, else: nil
+  def presence(atom, default \\ nil) do
+    if is_present(atom), do: atom, else: default
   end
 end
 
@@ -182,8 +205,8 @@ defimpl Presence, for: BitString do
 
   def is_present(string), do: !is_blank(string)
 
-  def presence(string) do
-    if is_present(string), do: string, else: nil
+  def presence(string, default \\ nil) do
+    if is_present(string), do: string, else: default
   end
 end
 
@@ -192,7 +215,7 @@ defimpl Presence, for: Float do
 
   def is_present(_), do: true
 
-  def presence(float), do: float
+  def presence(float, _default \\ nil), do: float
 end
 
 defimpl Presence, for: Integer do
@@ -200,7 +223,7 @@ defimpl Presence, for: Integer do
 
   def is_present(_), do: true
 
-  def presence(integer), do: integer
+  def presence(integer, _default \\ nil), do: integer
 end
 
 defimpl Presence, for: List do
@@ -214,8 +237,8 @@ defimpl Presence, for: List do
 
   def is_present(charlist), do: !is_blank(charlist)
 
-  def presence(charlist) do
-    if is_present(charlist), do: charlist, else: nil
+  def presence(charlist, default \\ nil) do
+    if is_present(charlist), do: charlist, else: default
   end
 end
 
@@ -227,8 +250,8 @@ defimpl Presence, for: Map do
 
   def is_present(map), do: !is_blank(map)
 
-  def presence(map) do
-    if is_present(map), do: map, else: nil
+  def presence(map, default \\ nil) do
+    if is_present(map), do: map, else: default
   end
 end
 
@@ -240,7 +263,7 @@ defimpl Presence, for: Tuple do
 
   def is_present(tuple), do: !is_blank(tuple)
 
-  def presence(tuple) do
-    if is_present(tuple), do: tuple, else: nil
+  def presence(tuple, default \\ nil) do
+    if is_present(tuple), do: tuple, else: default
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Presence.Mixfile do
       # Coveralls
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/test/presence/atom/atom_test.exs
+++ b/test/presence/atom/atom_test.exs
@@ -1,15 +1,27 @@
 defmodule AtomPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for `:true`" do
     assert presence(:true) == :true
+  end
+
+  test "presence for `:true` with default" do
+    assert presence(:true, :atom) == :true
   end
 
   test "presence for `:false`" do
     assert presence(:false) == nil
   end
 
+  test "presence for `:false` with default" do
+    assert presence(:false, :atom) == :atom
+  end
+
   test "presence for `:atom`" do
     assert presence(:atom) == :atom
+  end
+
+  test "presence for `:atom`, with default" do
+    assert presence(:atom, :another_atom) == :atom
   end
 end

--- a/test/presence/atom/boolean_test.exs
+++ b/test/presence/atom/boolean_test.exs
@@ -1,11 +1,19 @@
 defmodule BooleanPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for `true`" do
     assert presence(true) == true
   end
 
+  test "presence for `true` with default" do
+    assert presence(true, :default) == true
+  end
+
   test "presence for `false`" do
     assert presence(false) == nil
+  end
+
+  test "presence for `false` with default" do
+    assert presence(false, :default) == :default
   end
 end

--- a/test/presence/float_test.exs
+++ b/test/presence/float_test.exs
@@ -1,5 +1,5 @@
 defmodule FloatPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence" do
     assert presence(1.1) == 1.1

--- a/test/presence/integer_test.exs
+++ b/test/presence/integer_test.exs
@@ -1,7 +1,11 @@
 defmodule IntegerPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence" do
     assert presence(1) == 1
+  end
+
+  test "presence with default" do
+    assert presence(1, 2) == 1
   end
 end

--- a/test/presence/list/charlist_test.exs
+++ b/test/presence/list/charlist_test.exs
@@ -1,13 +1,25 @@
 defmodule CharlistPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for blank charlist" do
     charlist = ' '
     assert presence(charlist) == nil
   end
 
+  test "presence for blank charlist with default" do
+    charlist = ' '
+    default = 'a'
+    assert presence(charlist, default) == default
+  end
+
   test "presence for non-blank charlist" do
     charlist = 'a'
     assert presence(charlist) == charlist
+  end
+
+  test "presence for non-blank charlist with default" do
+    charlist = 'a'
+    default = 'b'
+    assert presence(charlist, default) == charlist
   end
 end

--- a/test/presence/list/non_charlist_test.exs
+++ b/test/presence/list/non_charlist_test.exs
@@ -1,13 +1,25 @@
 defmodule NonCharlistPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for empty list" do
     list = []
     assert presence(list) == nil
   end
 
+  test "presence for empty list with default" do
+    list = []
+    default = [0]
+    assert presence(list, default) == default
+  end
+
   test "presence for non-empty list" do
     list = [1]
     assert presence(list) == list
+  end
+
+  test "presence for non-empty list with default" do
+    list = [1]
+    default = [2]
+    assert presence(list, default) == list
   end
 end

--- a/test/presence/map_test.exs
+++ b/test/presence/map_test.exs
@@ -1,13 +1,25 @@
 defmodule MapPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for empty map" do
     map = %{}
     assert presence(map) == nil
   end
 
+  test "presence for empty map with default" do
+    map = %{}
+    default = %{count: 0}
+    assert presence(map, default) == default
+  end
+
   test "presence for non-empty map" do
     map = %{count: 1}
     assert presence(map) == map
+  end
+
+  test "presence for non-empty map with default" do
+    map = %{count: 1}
+    default = %{count: 0}
+    assert presence(map, default) == map
   end
 end

--- a/test/presence/string_test.exs
+++ b/test/presence/string_test.exs
@@ -1,13 +1,25 @@
 defmodule StringPresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for empty string" do
     string = "    "
     assert presence(string) == nil
   end
 
+  test "presence for empty string with default" do
+    string = "    "
+    default = "hello"
+    assert presence(string, default) == default
+  end
+
   test "presence for non-empty string" do
     string = "hello"
     assert presence(string) == string
+  end
+
+  test "presence for non-empty string with default" do
+    string = "hello"
+    default = "goodbye"
+    assert presence(string, default) == string
   end
 end

--- a/test/presence/tuple_test.exs
+++ b/test/presence/tuple_test.exs
@@ -1,13 +1,25 @@
 defmodule TuplePresenceTest do
-  use Presence.TestCase, only: [presence: 1]
+  use Presence.TestCase, only: [presence: 1, presence: 2]
 
   test "presence for empty tuple" do
     tuple = {}
     assert presence(tuple) == nil
   end
 
+  test "presence for empty tuple with default" do
+    tuple = {}
+    default = {:ok, 1}
+    assert presence(tuple, default) == default
+  end
+
   test "presence for non-empty tuple" do
     tuple = {:ok, 1}
     assert presence(tuple) == tuple
+  end
+
+  test "presence for non-empty tuple with default" do
+    tuple = {:ok, 1}
+    default = {:ok, 0}
+    assert presence(tuple, default) == tuple
   end
 end


### PR DESCRIPTION
- fix warning related to depreciated String.strip/1
- fix warning for quoted keyword where quotes are not needed
- add presence/2 to support a default when value is not present
